### PR TITLE
All target_link_libraries need to match style

### DIFF
--- a/example/CMakeLists.txt
+++ b/example/CMakeLists.txt
@@ -88,9 +88,9 @@ if (PNTR_APP_BUILD_EXAMPLE_RAYLIB OR EMSCRIPTEN)
     endif()
 
     if (APPLE AND NOT EMSCRIPTEN)
-        target_link_libraries(pntr_app_example_raylib "-framework IOKit")
-        target_link_libraries(pntr_app_example_raylib "-framework Cocoa")
-        target_link_libraries(pntr_app_example_raylib "-framework OpenGL")
+        target_link_libraries(pntr_app_example_raylib PUBLIC "-framework IOKit")
+        target_link_libraries(pntr_app_example_raylib PUBLIC "-framework Cocoa")
+        target_link_libraries(pntr_app_example_raylib PUBLIC "-framework OpenGL")
     endif()
 
     target_link_libraries(pntr_app_example_raylib PUBLIC


### PR DESCRIPTION
Essentially, there are 2 styles: "old" and "new" on calls to `target_link_libraries`. Was using a mix, but cmake wants them all to use one or the other, or you will get errors like this:

```
CMake Error at example/CMakeLists.txt:96 (target_link_libraries):
  The plain signature for target_link_libraries has already been used with
  the target "pntr_app_example_raylib".  All uses of target_link_libraries
  with a target must be either all-keyword or all-plain.

  The uses of the plain signature are here:

   * example/CMakeLists.txt:91 (target_link_libraries)
   * example/CMakeLists.txt:92 (target_link_libraries)
   * example/CMakeLists.txt:93 (target_link_libraries)
```