### PR TITLE
URL.revokeObjectURL

### DIFF
--- a/include/pntr_app_web.h
+++ b/include/pntr_app_web.h
@@ -98,7 +98,7 @@ EM_JS(void, pntr_unload_sound, (pntr_sound* sound), {
     if (audio) {
         audio.pause();
         audio.currentTime = 0;
-        revokeObjectURL(audio.src);
+        URL.revokeObjectURL(audio.src);
     }
 })
 


### PR DESCRIPTION
`revokeObjectURL`  is not in global scope.

<img width="613" alt="Screenshot 2024-06-30 at 5 35 47 PM" src="https://github.com/RobLoach/pntr_app/assets/83857/be2a5735-c3a3-4fd0-b488-3ca221e0433d">

This will use `URL.revokeObjectURL`, which is what was intended here.