### PR TITLE
WIP: New Audio (seek/stream)

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ void pntr_unload_sound(pntr_sound* sound);
 void pntr_play_sound(pntr_sound* sound, bool loop);
 void pntr_stop_sound(pntr_sound* sound);
 void pntr_seek_sound(pntr_sound* sound, int timeMs);
-void pntr_set_stream_handler(pntr_audio_stream_handler* cb);
+void pntr_set_audio_stream_handler(pntr_audio_stream_handler* cb);
 ```
 
 For drawing, see the [pntr API](https://github.com/RobLoach/pntr).

--- a/README.md
+++ b/README.md
@@ -110,6 +110,8 @@ pntr_sound* pntr_load_sound_from_memory(pntr_app_sound_type type, unsigned char*
 void pntr_unload_sound(pntr_sound* sound);
 void pntr_play_sound(pntr_sound* sound, bool loop);
 void pntr_stop_sound(pntr_sound* sound);
+void pntr_seek_sound(pntr_sound* sound, int timeMs);
+void pntr_set_stream_handler(pntr_audio_stream_handler* cb);
 ```
 
 For drawing, see the [pntr API](https://github.com/RobLoach/pntr).

--- a/example/CMakeLists.txt
+++ b/example/CMakeLists.txt
@@ -141,7 +141,7 @@ if (PNTR_APP_BUILD_EXAMPLE_WEB AND EMSCRIPTEN)
     set_property(TARGET pntr_app_example_web PROPERTY C_STANDARD 11)
     set_target_properties(pntr_app_example_web PROPERTIES SUFFIX ".html")
     set_target_properties(pntr_app_example_web PROPERTIES OUTPUT_NAME "index")
-    set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -s ASSERTIONS=1 -s WASM=1 --preload-file resources@/resources --shell-file ${CMAKE_SOURCE_DIR}/example/pntr_app_example.html")
+    set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -s AUDIO_WORKLET=1 -s WASM_WORKERS=1 -s ASSERTIONS=1 -s WASM=1 --preload-file resources@/resources --shell-file ${CMAKE_SOURCE_DIR}/example/pntr_app_example.html")
     # Strict Warnings and Errors
     if(MSVC)
         target_compile_options(pntr_app_example_web PRIVATE /W4 /WX)

--- a/include/external/sokol_args.h
+++ b/include/external/sokol_args.h
@@ -695,7 +695,7 @@ extern "C" {
 #endif
 
 #if defined(EM_JS_DEPS)
-EM_JS_DEPS(sokol_audio, "$withStackSave,$stringToUTF8OnStack");
+EM_JS_DEPS(sokol_audio, "$withStackSave,$stringToUTF8OnStack")
 #endif
 
 EMSCRIPTEN_KEEPALIVE void _sargs_add_kvp(const char* key, const char* val) {
@@ -739,7 +739,7 @@ EM_JS(void, sargs_js_parse_url, (void), {
             __sargs_add_kvp(key_cstr, val_cstr)
         });
     }
-});
+})
 
 #endif /* EMSCRIPTEN */
 

--- a/include/pntr_app.h
+++ b/include/pntr_app.h
@@ -451,7 +451,7 @@ PNTR_APP_API pntr_app_sound_type pntr_app_get_file_sound_type(const char* fileNa
 #endif
 
 /**
- * Used by pntr_set_stream_handler as callback
+ * Used by pntr_set_audio_stream_handler as callback
  */
 typedef void (pntr_audio_stream_handler)(
   int numInputs, const AudioSampleFrame *inputs,
@@ -476,7 +476,7 @@ void pntr_seek_sound(pntr_sound* sound, int timeMs);
  *
  * @param cb This will be called on every audio-frame, in another thread, to generate or process sound.
  */
-void pntr_set_stream_handler(pntr_audio_stream_handler* cb);
+void pntr_set_audio_stream_handler(pntr_audio_stream_handler* cb);
 
 /**
  * Get the user data associated with the application.

--- a/include/pntr_app.h
+++ b/include/pntr_app.h
@@ -427,7 +427,7 @@ PNTR_APP_API void pntr_stop_sound(pntr_sound* sound);
  */
 PNTR_APP_API pntr_app_sound_type pntr_app_get_file_sound_type(const char* fileName);
 
-#ifdef EMSCIRPTEN
+#ifdef EMSCRIPTEN
     #include <emscripten/webaudio.h>
 #else
     // these are part of emscripten, so I define here for native, so defs are shared
@@ -453,13 +453,10 @@ PNTR_APP_API pntr_app_sound_type pntr_app_get_file_sound_type(const char* fileNa
 /**
  * Used by pntr_set_audio_stream_handler as callback
  */
-typedef void (pntr_audio_stream_handler)(
+typedef bool (pntr_audio_stream_handler)(
   int numInputs, const AudioSampleFrame *inputs,
   int numOutputs, AudioSampleFrame *outputs,
   int numParams, const AudioParamFrame *params,
-  const int currentFrame,
-  const int currentTime,
-  const int sampleRate,
   void *userData
 );
 

--- a/include/pntr_app.h
+++ b/include/pntr_app.h
@@ -427,6 +427,57 @@ PNTR_APP_API void pntr_stop_sound(pntr_sound* sound);
  */
 PNTR_APP_API pntr_app_sound_type pntr_app_get_file_sound_type(const char* fileName);
 
+#ifdef EMSCIRPTEN
+    #include <emscripten/webaudio.h>
+#else
+    // these are part of emscripten, so I define here for native, so defs are shared
+    typedef struct AudioSampleFrame {
+    // Number of audio channels to process (multiplied by samplesPerChannel gives the elements in data)
+    const int numberOfChannels;
+    // Number of samples per channel in data
+    const int samplesPerChannel;
+    // An array of length numberOfChannels*samplesPerChannel elements. Samples are always arranged in a planar fashion,
+    // where data[channelIndex*samplesPerChannel+i] locates the data of the i'th sample of channel channelIndex.
+    float *data;
+    } AudioSampleFrame;
+
+    typedef struct AudioParamFrame {
+    // Specifies the length of the input array data (in float elements). This will be guaranteed to either have
+    // a value of 1, for a parameter valid for the entire frame, or emscripten_audio_context_quantum_size() for a parameter that changes per sample during the frame.
+    int length;
+    // An array of length specified in 'length'.
+    float *data;
+    } AudioParamFrame;
+#endif
+
+/**
+ * Used by pntr_set_stream_handler as callback
+ */
+typedef void (pntr_audio_stream_handler)(
+  int numInputs, const AudioSampleFrame *inputs,
+  int numOutputs, AudioSampleFrame *outputs,
+  int numParams, const AudioParamFrame *params,
+  const int currentFrame,
+  const int currentTime,
+  const int sampleRate,
+  void *userData
+);
+
+/**
+ * Set the current time of the given sound.
+ *
+ * @param sound The sound to set time of.
+ * @param timeMs The time, in milliseconds, form the beginning, to offset
+ */
+void pntr_seek_sound(pntr_sound* sound, int timeMs);
+
+/**
+ * Set an audio-callback
+ *
+ * @param cb This will be called on every audio-frame, in another thread, to generate or process sound.
+ */
+void pntr_set_stream_handler(pntr_audio_stream_handler* cb);
+
 /**
  * Get the user data associated with the application.
  *

--- a/include/pntr_app_web.h
+++ b/include/pntr_app_web.h
@@ -120,6 +120,17 @@ EM_JS(void, pntr_unload_sound, (pntr_sound* sound), {
     }
 })
 
+// seek a sound to a specirfic time-location
+EM_JS(void, pntr_seek_sound, (pntr_sound* sound, int timeMs), {
+    const audio = Module.pntr_sounds[sound - 1];
+    audio.currentTime = timeMs / 1000;
+})
+
+// register an audio-generating callback, use NULL to disable current 
+void pntr_set_stream_handler(pntr_audio_stream_handler* cb) {
+    // TODO: STUB
+}
+
 /**
  * : Initializes the canvas context.
  *

--- a/include/pntr_app_web.h
+++ b/include/pntr_app_web.h
@@ -126,6 +126,7 @@ EM_JS(void, pntr_seek_sound, (pntr_sound* sound, int timeMs), {
     audio.currentTime = timeMs / 1000;
 })
 
+
 // register an audio-generating callback, use NULL to disable current 
 void pntr_set_stream_handler(pntr_audio_stream_handler* cb) {
     // TODO: STUB

--- a/include/pntr_app_web.h
+++ b/include/pntr_app_web.h
@@ -128,7 +128,7 @@ EM_JS(void, pntr_seek_sound, (pntr_sound* sound, int timeMs), {
 
 
 // register an audio-generating callback, use NULL to disable current 
-void pntr_set_stream_handler(pntr_audio_stream_handler* cb) {
+void pntr_set_audio_stream_handler(pntr_audio_stream_handler* cb) {
     // TODO: STUB
 }
 


### PR DESCRIPTION
This will update a few things, but is not complete (will update this PR when I finish it)

- sokol_args had extra semicolons that were preventing web-build on Linux
- `void pntr_seek_sound(pntr_sound* sound, int timeMs)` that will allow you to set the time-offset of sounds
- `void pntr_set_audio_stream_handler(pntr_audio_stream_handler* cb)` that will allow you to make audio-stream (with callback) for more advanced usecases (custom instruments and dynamic-out, like making a music-tracker)
- Currently, all sound stuff uses `audio` elements, but it could be also done with an `AudioContext` (similar to callback setup) for gapless looping & better management, overall.

These API changes can serve as a prototype for similar changes on other backends, and will not change any other part of the audio API. 