### PR TITLE
Feature 120 seperate sound

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,6 @@ build
 *.so
 *.o
 *.bc
+
+# default log for CLI
+log.txt

--- a/example/CMakeLists.txt
+++ b/example/CMakeLists.txt
@@ -122,6 +122,7 @@ if (PNTR_APP_BUILD_EXAMPLE_CLI AND NOT EMSCRIPTEN)
     add_executable(pntr_app_example_cli pntr_app_example.c)
     target_link_libraries(pntr_app_example_cli PUBLIC pntr pntr_app)
     target_compile_definitions(pntr_app_example_cli PUBLIC PNTR_APP_CLI)
+    target_compile_definitions(pntr_app_example_cli PUBLIC PNTR_APP_NOSOUND)
     set_property(TARGET pntr_app_example_cli PROPERTY C_STANDARD 11)
     # Strict Warnings and Errors
     if(MSVC)

--- a/example/CMakeLists.txt
+++ b/example/CMakeLists.txt
@@ -122,7 +122,6 @@ if (PNTR_APP_BUILD_EXAMPLE_CLI AND NOT EMSCRIPTEN)
     add_executable(pntr_app_example_cli pntr_app_example.c)
     target_link_libraries(pntr_app_example_cli PUBLIC pntr pntr_app)
     target_compile_definitions(pntr_app_example_cli PUBLIC PNTR_APP_CLI)
-    target_compile_definitions(pntr_app_example_cli PUBLIC PNTR_APP_NOSOUND)
     set_property(TARGET pntr_app_example_cli PROPERTY C_STANDARD 11)
     # Strict Warnings and Errors
     if(MSVC)

--- a/include/pntr_app.h
+++ b/include/pntr_app.h
@@ -636,12 +636,12 @@ PNTR_APP_API void pntr_app_log_ex(pntr_app_log_type type, const char* message, .
 #endif
 
 #define PNTR_APP_HEADER_ONLY
+#include "pntr_app_nosound.h"
 #include "pntr_app_cli.h"
 #include "pntr_app_libretro.h"
 #include "pntr_app_raylib.h"
 #include "pntr_app_sdl.h"
 #include "pntr_app_web.h"
-#include "pntr_app_nosound.h"
 #undef PNTR_APP_HEADER_ONLY
 
 #ifdef __cplusplus
@@ -687,12 +687,12 @@ extern "C" {
 
 pntr_app PNTR_APP_MAIN(int argc, char* argv[]);
 
+#include "pntr_app_nosound.h"
 #include "pntr_app_cli.h"
 #include "pntr_app_libretro.h"
 #include "pntr_app_raylib.h"
 #include "pntr_app_sdl.h"
 #include "pntr_app_web.h"
-#include "pntr_app_nosound.h"
 
 #ifdef __cplusplus
 }

--- a/include/pntr_app.h
+++ b/include/pntr_app.h
@@ -641,6 +641,7 @@ PNTR_APP_API void pntr_app_log_ex(pntr_app_log_type type, const char* message, .
 #include "pntr_app_raylib.h"
 #include "pntr_app_sdl.h"
 #include "pntr_app_web.h"
+#include "pntr_app_nosound.h"
 #undef PNTR_APP_HEADER_ONLY
 
 #ifdef __cplusplus
@@ -691,6 +692,7 @@ pntr_app PNTR_APP_MAIN(int argc, char* argv[]);
 #include "pntr_app_raylib.h"
 #include "pntr_app_sdl.h"
 #include "pntr_app_web.h"
+#include "pntr_app_nosound.h"
 
 #ifdef __cplusplus
 }

--- a/include/pntr_app_cli.h
+++ b/include/pntr_app_cli.h
@@ -314,26 +314,6 @@ void pntr_app_platform_close(pntr_app* app) {
     app->platform = NULL;
 }
 
-pntr_sound* pntr_load_sound_from_memory(pntr_app_sound_type type, unsigned char* data, unsigned int dataSize) {
-    (void)type;
-    (void)data;
-    (void)dataSize;
-    return NULL;
-}
-
-void pntr_unload_sound(pntr_sound* sound) {
-    (void)sound;
-}
-
-void pntr_play_sound(pntr_sound* sound, bool loop) {
-    (void)sound;
-    (void)loop;
-}
-
-void pntr_stop_sound(pntr_sound* sound) {
-    (void)sound;
-}
-
 bool pntr_app_platform_update_delta_time(pntr_app* app) {
     // TODO: Make CLI delta time get the actual delta time.
     if (app->fps <= 0) {

--- a/include/pntr_app_nosound.h
+++ b/include/pntr_app_nosound.h
@@ -1,0 +1,33 @@
+#ifdef PNTR_APP_NOSOUND
+#ifndef PNTR_APP_NOSOUND_H__
+#define PNTR_APP_NOSOUND_H__
+
+#endif  // PNTR_APP_NOSOUND_H__
+
+#if defined(PNTR_APP_IMPLEMENTATION) && !defined(PNTR_APP_HEADER_ONLY)
+#ifndef PNTR_APP_NOSOUND_IMPLEMENTATION_ONCE
+#define PNTR_APP_NOSOUND_IMPLEMENTATION_ONCE
+
+pntr_sound* pntr_load_sound_from_memory(pntr_app_sound_type type, unsigned char* data, unsigned int dataSize) {
+    (void)type;
+    (void)data;
+    (void)dataSize;
+    return NULL;
+}
+
+void pntr_unload_sound(pntr_sound* sound) {
+    (void)sound;
+}
+
+void pntr_play_sound(pntr_sound* sound, bool loop) {
+    (void)sound;
+    (void)loop;
+}
+
+void pntr_stop_sound(pntr_sound* sound) {
+    (void)sound;
+}
+
+#endif  // PNTR_APP_NOSOUND_IMPLEMENTATION_ONCE
+#endif  // PNTR_APP_IMPLEMENTATION && !PNTR_APP_HEADER_ONLY
+#endif  // PNTR_APP_NOSOUND

--- a/include/pntr_app_platform.h
+++ b/include/pntr_app_platform.h
@@ -26,6 +26,11 @@
     #endif
 #endif
 
+// some targets have no sound of their own
+#if !defined(PNTR_APP_WEB) && !defined(PNTR_APP_LIBRETRO) && !defined(PNTR_APP_RAYLIB) && !defined(PNTR_APP_SDL_MIXER) && !defined(PNTR_APP_MINIAUDIO)
+#define PNTR_APP_NOSOUND
+#endif
+
 // Pixel Format
 #if defined(PNTR_APP_SDL) || defined(PNTR_APP_LIBRETRO)
     #ifndef PNTR_PIXELFORMAT_ARGB


### PR DESCRIPTION
Related to #120 

This adds a var `PNTR_APP_NOSOUND` for graphical targets that do not have sound.

I think it allows combos like `PNTR_APP_SDL_MIXER` + `PNTR_APP_CLI`, but in the future it will allow `PNTR_APP_MINIAUDIO` with `PNTR_APP_CLI` and `PNTR_APP_RGFW`.