### PR TITLE
raylib gamepad: remove break

### DIFF
--- a/include/pntr_app_raylib.h
+++ b/include/pntr_app_raylib.h
@@ -361,9 +361,6 @@ bool pntr_app_platform_events(pntr_app* app) {
                 }
             }
         }
-        else {
-            break;
-        }
     }
 
     // File Dropped


### PR DESCRIPTION
It's possible to have no 0, but have a 1, for example. This will loop through all possible gamepads. I tested on mac with a joystick that registers as 1, so it was not finding it (since there is no 0 on my system.)