### PR TITLE
SDL: Add Super/GUI key mapping

### DIFF
--- a/include/pntr_app_sdl.h
+++ b/include/pntr_app_sdl.h
@@ -426,6 +426,8 @@ pntr_app_key pntr_app_sdl_key(SDL_Keycode key) {
         case SDLK_RSHIFT: return PNTR_APP_KEY_RIGHT_SHIFT;
         case SDLK_RCTRL: return PNTR_APP_KEY_RIGHT_CONTROL;
         case SDLK_RALT: return PNTR_APP_KEY_RIGHT_ALT;
+        case SDLK_LGUI: return PNTR_APP_KEY_LEFT_SUPER;
+        case SDLK_RGUI: return PNTR_APP_KEY_RIGHT_SUPER;
         case SDLK_MENU: return PNTR_APP_KEY_MENU;
         default:
             return PNTR_APP_KEY_INVALID;


### PR DESCRIPTION
Map SDLK_LGUI/SDLK_RGUI to PNTR_APP_KEY_LEFT_SUPER/RIGHT_SUPER. Fixes #144